### PR TITLE
Fix for malformed id in nested edit templates

### DIFF
--- a/src/MvcCheckBoxList/ListBuilder.cs
+++ b/src/MvcCheckBoxList/ListBuilder.cs
@@ -305,10 +305,10 @@ namespace MvcCheckBoxList.Library {
       checkbox_builder.MergeAttribute("name", fullName);
 
       // create linked label tag
-      var link_name = name + linked_label_counter++;
-      checkbox_builder.GenerateId(link_name);
+      var link_id = htmlHelper.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldId(name) + linked_label_counter++;
+      checkbox_builder.GenerateId(link_id);
       var linked_label_builder = new TagBuilder("label");
-      linked_label_builder.MergeAttribute("for", link_name.Replace(".", "_"));
+      linked_label_builder.MergeAttribute("for", link_id);
       linked_label_builder.MergeAttributes(htmlAttributesForCheckBox.toDictionary());
       linked_label_builder.InnerHtml = itemText;
 


### PR DESCRIPTION
I had a scenario where I was calling @Html.EditorFor() on a collection of items that each end up rendering as their own EditorTemplate.  For instance  I have a the following:
```
public class SomeFolksViewModel
{
	public string State {get; set;}
	public IList<Person> People {get; set;}
}

public class Person
{
	public string Name {get; set;}
	public IList<CheckboxListItem> TeethQuantityAvailable { get; set; }
	public IList<CheckboxListItem> TeethQuantitySelected { get; set; }
	public PostedTeethQuantity PostedTeethQuantitys { get; set; }
}

public class PostedTeethQuantity 
{
	public string[] TeethQuantitys { get; set; }
}

// SomeFolksView.chstml
@model SomeFolksViewModel
<div class="form-group">
	@Html.LabelFor(m => m.State)
	@Html.TextBoxFor(m => m.State, new { @class = "form-control" })
	@Html.ValidationMessageFor(m => m.State)
</div>
<div class="form-group">
	@Html.EditorFor(m => m.People)
</div>

// EditorTemplate/Person.cshtml
@model Person
<div class="form-group">
	@Html.LabelFor(m => m.Name)
	@Html.TextBoxFor(m => m.Name, new { @class = "form-control" })
	@Html.ValidationMessageFor(m => m.Name)
</div>
<div class="checkbox">
	@Html.CheckBoxListFor(model => model.PostedTeethQuantitys.TeethQuantitys,
		model => model.TeethQuantityAvailable,
		entity => entity.Name,
		entity => entity.Name,
		model => model.TeethQuantitySelected, Position.Vertical)
</div>
```
say I create the ViewModel and load 2 Person into the People collection.  I add 3 entries to TeethQuantityAvailablecollection "All","Some","None".

ok, I run this and I end up with rendered CBL but the id's are wrong.

I end up with something like this (i've ommited labels, etc.) for person 1
```
<input id="PostedTeethQuantity_TeethQuantitys1" name="People[0].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> All
<input id="PostedTeethQuantity_TeethQuantitys2" name="People[0].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> Some
<input id="PostedTeethQuantity_TeethQuantitys3" name="People[0].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> None
```
and this for person 2
```
<input id="PostedTeethQuantity_TeethQuantitys4" name="People[1].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> All
<input id="PostedTeethQuantity_TeethQuantitys5" name="People[1].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> Some
<input id="PostedTeethQuantity_TeethQuantitys6" name="People[1].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> None
```
This does not work.  The Id's are malformed, they are missing their parent object name.  When the page is posted back the ID's don't properly map back to the viewmodel and I end up with a lot of extra People in my list.

To make it work the cbl Ids should look like the following

Person 1:
```
<input id="People_0__PostedTeethQuantity_TeethQuantitys1" name="People[0].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> All
<input id="People_0__PostedTeethQuantity_TeethQuantitys2" name="People[0].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> Some
<input id="People_0__PostedTeethQuantity_TeethQuantitys3" name="People[0].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> None
```
Person 2:
```
<input id="People_1__PostedTeethQuantity_TeethQuantitys4" name="People[1].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> All
<input id="People_1__PostedTeethQuantity_TeethQuantitys5" name="People[1].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> Some
<input id="People_1__PostedTeethQuantity_TeethQuantitys6" name="People[1].PostedTeethQuantity.TeethQuantitys" type="checkbox" /> None
```