### PR TITLE
Corrected tag-closing mode

### DIFF
--- a/src/MvcCheckBoxList.net40/ListBuilder.cs
+++ b/src/MvcCheckBoxList.net40/ListBuilder.cs
@@ -344,7 +344,7 @@ namespace MvcCheckBoxList.Library {
           hidden_input_builder.MergeAttribute("type", "hidden");
           hidden_input_builder.MergeAttribute("value", itemValue);
           hidden_input_builder.MergeAttribute("name", name);
-          sb.Append(hidden_input_builder.ToString(TagRenderMode.Normal));
+          sb.Append(hidden_input_builder.ToString(TagRenderMode.SelfClosing));
         }
       }
 
@@ -352,10 +352,10 @@ namespace MvcCheckBoxList.Library {
       if (textLayout == TextLayout.RightToLeft) {
         // then display checkbox for right-to-left languages
         sb.Append(linked_label_builder.ToString(TagRenderMode.Normal));
-        sb.Append(checkbox_builder.ToString(TagRenderMode.Normal));
+        sb.Append(checkbox_builder.ToString(TagRenderMode.SelfClosing));
       }
       else {
-        sb.Append(checkbox_builder.ToString(TagRenderMode.Normal));
+        sb.Append(checkbox_builder.ToString(TagRenderMode.SelfClosing));
         sb.Append(linked_label_builder.ToString(TagRenderMode.Normal));
       }
 

--- a/src/MvcCheckBoxList/ListBuilder.cs
+++ b/src/MvcCheckBoxList/ListBuilder.cs
@@ -345,7 +345,7 @@ namespace MvcCheckBoxList.Library {
           hidden_input_builder.MergeAttribute("type", "hidden");
           hidden_input_builder.MergeAttribute("value", itemValue);
           hidden_input_builder.MergeAttribute("name", name);
-          sb.Append(hidden_input_builder.ToString(TagRenderMode.Normal));
+          sb.Append(hidden_input_builder.ToString(TagRenderMode.SelfClosing));
         }
       }
 
@@ -353,10 +353,10 @@ namespace MvcCheckBoxList.Library {
       if (textLayout == TextLayout.RightToLeft) {
         // then display checkbox for right-to-left languages
         sb.Append(linked_label_builder.ToString(TagRenderMode.Normal));
-        sb.Append(checkbox_builder.ToString(TagRenderMode.Normal));
+        sb.Append(checkbox_builder.ToString(TagRenderMode.SelfClosing));
       }
       else {
-        sb.Append(checkbox_builder.ToString(TagRenderMode.Normal));
+        sb.Append(checkbox_builder.ToString(TagRenderMode.SelfClosing));
         sb.Append(linked_label_builder.ToString(TagRenderMode.Normal));
       }
 


### PR DESCRIPTION
Changed TagRenderMode to TagRenderMode.SelfClosing for input elements.

Did not exhaustively test this, but ran the included MVC4 site in IE, Firefox, and Chrome, and both versions of the library seem to generate self-closing input tags now.

This fixes #11 